### PR TITLE
修复米游社原神绑定的账号中存在低于10级的账号时会出现```list index out of range```的bug

### DIFF
--- a/genshinhelper/mihoyo.py
+++ b/genshinhelper/mihoyo.py
@@ -51,10 +51,25 @@ class YuanShen(Client):
     @property
     def travelers_dairy(self):
         roles_info = self.roles_info
+        """
         self._travelers_dairy = [
             self.get_travelers_dairy(i['game_uid'], i['region'])
             for i in roles_info
         ]
+        """
+        """
+        修复等级不足10级时无法查看旅行者札记(无法获取每个月获得的摩拉原石数量)
+        导致 _tp 为None
+        使 genshin-checkin-help 中会出现`list index out of range`的bug
+        """
+        self._travelers_dairy = []
+        for i in roles_info:
+            _tp = self.get_travelers_dairy(i['game_uid'], i['region'])
+            if _tp is None:
+                self._travelers_dairy.append({'month_data': {}})
+            else:
+                self._travelers_dairy.append(_tp)
+
         return self._travelers_dairy
 
     def get_travelers_dairy(self, uid: str, region: str, month: int = 0):


### PR DESCRIPTION
![4NBO%L~_B2}TCKLF8ZUHFMB](https://user-images.githubusercontent.com/33370220/183245009-116272af-9fb8-4d3a-9b9e-f22b347bc3cd.png)
